### PR TITLE
Add missing LF in maintainers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Each node is equipped with an 8-LED RGB strip where different LED's are used to 
 ## Maintainer(s)
 
 Eric Loots    - eric.loots@lightbend.com
+
 Kikia Carter  - kikia.carter@lightbend.com
+
 Duncan Devore - duncan.devore@lightbend.com
 
 ## Changelog


### PR DESCRIPTION
LF feeds were missing between maintainer entries leading to maintainers being listed on a single line when rendered