### PR TITLE
Make copy scripts easier to use on different clusters

### DIFF
--- a/copy
+++ b/copy
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # Set CLUSTER_NR to the number of the cluster you're working with
-CLUSTER_NR=0
+CLUSTER_NR_SEL=${CLUSTER_NR:?Set environment variable CLUSTER_NR to your cluster number}
 
-CLUSTER_BASE_NODE_NR=$(expr $CLUSTER_NR \* 5)
+CLUSTER_BASE_NODE_NR=$(expr $CLUSTER_NR_SEL \* 5)
 
 PI_USER=akkapi
 EXERCISE_NR=`printf %03d $1`
@@ -14,7 +14,7 @@ NODES=${SELECTED_NODE:-$ALL_NODES}
 echo "Using $FATJAR"
 
 for i in $NODES;do
-  node=$(expr $CLUSTER_BASE_NODE_NR + $i)
+  node=$[ CLUSTER_BASE_NODE_NR + i ]
   echo "Copy $FATJAR to node-${node}"
   scp $FATJAR ${PI_USER}@node-${node}:/home/${PI_USER}
 done

--- a/copySingle
+++ b/copySingle
@@ -1,12 +1,22 @@
 #!/bin/bash
 
+# Set CLUSTER_NR to the number of the cluster you're working with
+CLUSTER_NR_SEL=${CLUSTER_NR:?Set environment variable CLUSTER_NR to your cluster number}
+
+CLUSTER_BASE_NODE_NR=$(expr $CLUSTER_NR_SEL \* 5)
+
 PI_USER=akkapi
-#EXERCISE_NR=`printf %03d $1`
 FATJAR=`ls exercises/target/scala-2.12/exercise*jar`
+ALL_NODES="0 1 2 3 4"
+
+SELECTED_NODE=$2
+NODES=${SELECTED_NODE:-$ALL_NODES}
+
 echo "Using $FATJAR"
 
 for i in 0 1 2 3 4;do
+  node=$[ CLUSTER_BASE_NODE_NR + i ]
   echo "Copy $FATJAR to node-${i}"
-  scp $FATJAR ${PI_USER}@node-${i}:/home/${PI_USER}
+  scp $FATJAR ${PI_USER}@node-${node}:/home/${PI_USER}
 done
 


### PR DESCRIPTION
The assumption is that # of nodes in a cluster is 5. By setting the `CLUSTER_NR` environment variable, the `copy` and `copySingle` command will automatically calculate the names of the nodes in te cluster.