### PR TITLE
Add names to SudokuDetailProcessors + first stab at docs

### DIFF
--- a/exercise_015_clustered_sudoku_solver/src/test/resources/README.md
+++ b/exercise_015_clustered_sudoku_solver/src/test/resources/README.md
@@ -1,5 +1,7 @@
-clustered_sudoku_solver
+base_clustered_sudoku_solver
 
 # Clustered Sudoku Solver
 
-In this step, we add an actor based Sudoku solver. Each node will automatically start a solver and another actor will send the same sudoku problem in a continues loop.
+In this step, we add an actor based Sudoku solver. Each node 
+will automatically start a solver and another actor will send 
+the same sudoku problem in a continues loop.

--- a/exercise_016_add_cluster_client/src/main/scala/org/neopixel/AkkaHttpServer.scala
+++ b/exercise_016_add_cluster_client/src/main/scala/org/neopixel/AkkaHttpServer.scala
@@ -1,7 +1,6 @@
 package org.neopixel
 
 import akka.actor._
-import akka.pattern.ask
 import akka.cluster.client.{ClusterClient, ClusterClientSettings}
 import akka.http.scaladsl.server.{Directives, Route}
 import akka.http.scaladsl.Http

--- a/exercise_016_add_cluster_client/src/test/resources/README.md
+++ b/exercise_016_add_cluster_client/src/test/resources/README.md
@@ -1,5 +1,18 @@
-clustered_sudoku_solver
+clustered_sudoku_solver_add_http_client
 
-# Clustered Sudoku Solver
+# Clustered Sudoku Solver - Add Akka Cluster Client & HTTP server
 
-In this step, we add an actor based Sudoku solver. Each node will automatically start a solver and another actor will send the same sudoku problem in a continues loop.
+In this step, we add a HTTP server which will allow us to POST
+sudoko puzzlers to the clustered sudoku solver.
+
+The server should be started on your local machine (so not on the
+Raspberry Pi based Akka Cluster). The server is configured to 
+listen on port `8080`.
+
+Here's an example of posting a puzzle using `curl`:
+
+`curl --header "Content-Type: application/json" --request POST --data '{ "values": [[0,6,0,0,2,0,9,0,7], [0,0,0,3,6,9,0,0,0], [0,0,1,0,4,0,0,0,0], [0,9,8,0,0,5,0,0,0], [0,2,0,6,0,0,3,0,0], [0,0,0,0,0,0,0,0,9], [0,0,2,8,0,0,0,0,1], [0,0,0,0,0,7,0,6,0], [0,5,0,0,0,0,0,0,0]]}' localhost:8080/sudoku`
+
+The sudoku solver will be adapted in the next exercise to serve
+requests sent via the Akka Cluster Client
+

--- a/exercise_017_clustered_sudoku_solver_cluster_client_enabled/src/main/scala/org/neopixel/SudokuDetailProcessor.scala
+++ b/exercise_017_clustered_sudoku_solver_cluster_client_enabled/src/main/scala/org/neopixel/SudokuDetailProcessor.scala
@@ -21,22 +21,27 @@ object SudokuDetailProcessor {
 
   trait UpdateSender[A] {
     def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef): Unit
+
+    def processorName(id: Int): String
   }
 
   implicit val rowUpdateSender: UpdateSender[Row] = new UpdateSender[Row] {
     override def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef): Unit = {
       sender ! RowUpdate(id, cellUpdates)
     }
+    override def processorName(id: Int): String = s"row-processor-$id"
   }
 
   implicit val columnUpdateSender: UpdateSender[Column] = new UpdateSender[Column] {
     override def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef): Unit =
       sender ! ColumnUpdate(id, cellUpdates)
+    override def processorName(id: Int): String = s"col-processor-$id"
   }
 
   implicit val blockUpdateSender: UpdateSender[Block] = new UpdateSender[Block] {
     override def sendUpdate(id: Int, cellUpdates: CellUpdates)(implicit sender: ActorRef): Unit =
       sender ! BlockUpdate(id, cellUpdates)
+    override def processorName(id: Int): String = s"blk-processor-$id"
   }
 }
 

--- a/exercise_017_clustered_sudoku_solver_cluster_client_enabled/src/main/scala/org/neopixel/SudokuSolver.scala
+++ b/exercise_017_clustered_sudoku_solver_cluster_client_enabled/src/main/scala/org/neopixel/SudokuSolver.scala
@@ -11,9 +11,11 @@ object SudokuSolver {
   case class Result(sudoku: Sudoku)
 
   def genDetailProcessors[A <: SudokoDetailType : UpdateSender](context: ActorContext): Map[Int, ActorRef] = {
+
     cellIndexesVector.map {
       index =>
-        val detailProcessor = context.actorOf(SudokuDetailProcessor.props[A](index))
+        val detailProcessorName = implicitly[UpdateSender[A]].processorName(index)
+        val detailProcessor = context.actorOf(SudokuDetailProcessor.props[A](index), detailProcessorName)
         (index, detailProcessor)
     }.toMap
   }


### PR DESCRIPTION
- Sudoko detail processors (actors) didn't have custom names: added them.
- Started updating exercise READMEs