### PR TITLE
Increase "akka.cluster.seed-node-timeout" to avoid self-join on restart

### DIFF
--- a/exercise_004_cluster_base/src/main/resources/application.conf
+++ b/exercise_004_cluster_base/src/main/resources/application.conf
@@ -18,6 +18,8 @@ akka {
 
   cluster {
 
+    seed-node-timeout = 20 seconds
+
     management.http {
       //      host = 127.0.0.1
       port = 19999

--- a/exercise_005_cluster_base_move_to_artery_tcp/src/main/resources/application.conf
+++ b/exercise_005_cluster_base_move_to_artery_tcp/src/main/resources/application.conf
@@ -18,6 +18,8 @@ akka {
 
   cluster {
 
+    seed-node-timeout = 20 seconds
+
     management.http {
       //      host = 127.0.0.1
       port = 19999

--- a/exercise_006_cluster_weakly_up/src/main/resources/application.conf
+++ b/exercise_006_cluster_weakly_up/src/main/resources/application.conf
@@ -19,6 +19,8 @@ akka {
 
   cluster {
 
+    seed-node-timeout = 20 seconds
+
     management.http {
       //      host = 127.0.0.1
       port = 19999

--- a/exercise_007_cluster_cluster_singleton/src/main/resources/application.conf
+++ b/exercise_007_cluster_cluster_singleton/src/main/resources/application.conf
@@ -19,6 +19,8 @@ akka {
 
   cluster {
 
+    seed-node-timeout = 20 seconds
+
     management.http {
       //      host = 127.0.0.1
       port = 19999

--- a/exercise_008_cluster_the_perils_of_auto_downing/src/main/resources/application.conf
+++ b/exercise_008_cluster_the_perils_of_auto_downing/src/main/resources/application.conf
@@ -19,6 +19,8 @@ akka {
 
   cluster {
 
+    seed-node-timeout = 20 seconds
+
     auto-down-unreachable-after = 10 seconds // DON'T DO THIS !!!
 
     management.http {

--- a/exercise_009_cluster_weakly_up_disabled/src/main/resources/application.conf
+++ b/exercise_009_cluster_weakly_up_disabled/src/main/resources/application.conf
@@ -19,6 +19,8 @@ akka {
 
   cluster {
 
+    seed-node-timeout = 20 seconds
+
     allow-weakly-up-members = off
 
     management.http {

--- a/exercise_010_split_brain_resolver_keep_majority/src/main/resources/application.conf
+++ b/exercise_010_split_brain_resolver_keep_majority/src/main/resources/application.conf
@@ -21,6 +21,8 @@ akka {
 
   cluster {
 
+    seed-node-timeout = 20 seconds
+
     management.http {
       //      host = 127.0.0.1
       port = 19999

--- a/exercise_011_split_brain_resolver_static_quorum/src/main/resources/application.conf
+++ b/exercise_011_split_brain_resolver_static_quorum/src/main/resources/application.conf
@@ -21,6 +21,8 @@ akka {
 
   cluster {
 
+    seed-node-timeout = 20 seconds
+
     management.http {
       //      host = 127.0.0.1
       port = 19999

--- a/exercise_012_split_brain_resolver_keep_referee/src/main/resources/application.conf
+++ b/exercise_012_split_brain_resolver_keep_referee/src/main/resources/application.conf
@@ -21,6 +21,8 @@ akka {
 
   cluster {
 
+    seed-node-timeout = 20 seconds
+
     management.http {
       //      host = 127.0.0.1
       port = 19999

--- a/exercise_013_split_brain_resolver_keep_oldest/src/main/resources/application.conf
+++ b/exercise_013_split_brain_resolver_keep_oldest/src/main/resources/application.conf
@@ -21,6 +21,8 @@ akka {
 
   cluster {
 
+    seed-node-timeout = 20 seconds
+
     management.http {
       //      host = 127.0.0.1
       port = 19999

--- a/exercise_014_split_brain_resolver_static_quorum_http_mamagement/src/main/resources/application.conf
+++ b/exercise_014_split_brain_resolver_static_quorum_http_mamagement/src/main/resources/application.conf
@@ -21,6 +21,8 @@ akka {
 
   cluster {
 
+    seed-node-timeout = 20 seconds
+
     management.http {
 //      host = 127.0.0.1
       port = 19999

--- a/exercise_015_clustered_sudoku_solver/src/main/resources/application.conf
+++ b/exercise_015_clustered_sudoku_solver/src/main/resources/application.conf
@@ -21,6 +21,8 @@ akka {
 
   cluster {
 
+    seed-node-timeout = 20 seconds
+
     management.http {
 //      host = 127.0.0.1
       port = 19999

--- a/exercise_016_add_cluster_client/src/main/resources/application.conf
+++ b/exercise_016_add_cluster_client/src/main/resources/application.conf
@@ -21,6 +21,8 @@ akka {
 
   cluster {
 
+    seed-node-timeout = 20 seconds
+
     management.http {
 //      host = 127.0.0.1
       port = 19999

--- a/exercise_017_clustered_sudoku_solver_cluster_client_enabled/src/main/resources/application.conf
+++ b/exercise_017_clustered_sudoku_solver_cluster_client_enabled/src/main/resources/application.conf
@@ -23,6 +23,8 @@ akka {
 
   cluster {
 
+    seed-node-timeout = 20 seconds
+
     management.http {
 //      host = 127.0.0.1
       port = 19999


### PR DESCRIPTION
A side effect of running Akka Cluster on Raspberry-Pi is that it exposes a problem that can manifest itself on other hardware too.
A Raspberry Pi 3 Model B is certainly slower than a typical laptop or server hardware on which Akka Cluster is deployed. As a consequence, joining by a new node of an existing cluster is going to be slower on a Pi. In general this is not an issue except in the case of the first seed node restarting and re-joining an already existing cluster (this can happen when the first seed node is stopped and then started again). There's a setting in Akka Cluster configuration named `akka.cluster.seed-node-timeout` and, for the first seed node, this is the maximum time the node will wait to try to join an existing cluster. If the timeout expires, the first seed node will self-join which results in a split brain.
This PR increases the `akka.cluster.seed-node-timeout` to 20 seconds (from the 5 seconds default value).