### PR TITLE
Reduce seed-node-timeout to a lower value (default = 5 seconds)

### DIFF
--- a/exercise_004_cluster_base/src/main/resources/application.conf
+++ b/exercise_004_cluster_base/src/main/resources/application.conf
@@ -18,7 +18,7 @@ akka {
 
   cluster {
 
-    seed-node-timeout = 20 seconds
+    seed-node-timeout = 12 seconds
 
     management.http {
       //      host = 127.0.0.1

--- a/exercise_005_cluster_base_move_to_artery_tcp/src/main/resources/application.conf
+++ b/exercise_005_cluster_base_move_to_artery_tcp/src/main/resources/application.conf
@@ -18,7 +18,7 @@ akka {
 
   cluster {
 
-    seed-node-timeout = 60 seconds
+    seed-node-timeout = 12 seconds
 
     management.http {
       //      host = 127.0.0.1

--- a/exercise_006_cluster_weakly_up/src/main/resources/application.conf
+++ b/exercise_006_cluster_weakly_up/src/main/resources/application.conf
@@ -19,7 +19,7 @@ akka {
 
   cluster {
 
-    seed-node-timeout = 60 seconds
+    seed-node-timeout = 12 seconds
 
     management.http {
       //      host = 127.0.0.1

--- a/exercise_007_cluster_cluster_singleton/src/main/resources/application.conf
+++ b/exercise_007_cluster_cluster_singleton/src/main/resources/application.conf
@@ -19,7 +19,7 @@ akka {
 
   cluster {
 
-    seed-node-timeout = 60 seconds
+    seed-node-timeout = 12 seconds
 
     management.http {
       //      host = 127.0.0.1

--- a/exercise_008_cluster_the_perils_of_auto_downing/src/main/resources/application.conf
+++ b/exercise_008_cluster_the_perils_of_auto_downing/src/main/resources/application.conf
@@ -19,7 +19,7 @@ akka {
 
   cluster {
 
-    seed-node-timeout = 60 seconds
+    seed-node-timeout = 12 seconds
 
     auto-down-unreachable-after = 10 seconds // DON'T DO THIS !!!
 

--- a/exercise_009_cluster_weakly_up_disabled/src/main/resources/application.conf
+++ b/exercise_009_cluster_weakly_up_disabled/src/main/resources/application.conf
@@ -19,7 +19,7 @@ akka {
 
   cluster {
 
-    seed-node-timeout = 60 seconds
+    seed-node-timeout = 12 seconds
 
     allow-weakly-up-members = off
 

--- a/exercise_010_split_brain_resolver_keep_majority/src/main/resources/application.conf
+++ b/exercise_010_split_brain_resolver_keep_majority/src/main/resources/application.conf
@@ -21,7 +21,7 @@ akka {
 
   cluster {
 
-    seed-node-timeout = 60 seconds
+    seed-node-timeout = 12 seconds
 
     management.http {
       //      host = 127.0.0.1

--- a/exercise_011_split_brain_resolver_static_quorum/src/main/resources/application.conf
+++ b/exercise_011_split_brain_resolver_static_quorum/src/main/resources/application.conf
@@ -21,7 +21,7 @@ akka {
 
   cluster {
 
-    seed-node-timeout = 60 seconds
+    seed-node-timeout = 12 seconds
 
     management.http {
       //      host = 127.0.0.1

--- a/exercise_012_split_brain_resolver_keep_referee/src/main/resources/application.conf
+++ b/exercise_012_split_brain_resolver_keep_referee/src/main/resources/application.conf
@@ -21,7 +21,7 @@ akka {
 
   cluster {
 
-    seed-node-timeout = 60 seconds
+    seed-node-timeout = 12 seconds
 
     management.http {
       //      host = 127.0.0.1

--- a/exercise_013_split_brain_resolver_keep_oldest/src/main/resources/application.conf
+++ b/exercise_013_split_brain_resolver_keep_oldest/src/main/resources/application.conf
@@ -21,7 +21,7 @@ akka {
 
   cluster {
 
-    seed-node-timeout = 60 seconds
+    seed-node-timeout = 12 seconds
 
     management.http {
       //      host = 127.0.0.1

--- a/exercise_014_split_brain_resolver_static_quorum_http_mamagement/src/main/resources/application.conf
+++ b/exercise_014_split_brain_resolver_static_quorum_http_mamagement/src/main/resources/application.conf
@@ -21,7 +21,7 @@ akka {
 
   cluster {
 
-    seed-node-timeout = 60 seconds
+    seed-node-timeout = 12 seconds
 
     management.http {
 //      host = 127.0.0.1

--- a/exercise_015_clustered_sudoku_solver/src/main/resources/application.conf
+++ b/exercise_015_clustered_sudoku_solver/src/main/resources/application.conf
@@ -21,7 +21,7 @@ akka {
 
   cluster {
 
-    seed-node-timeout = 60 seconds
+    seed-node-timeout = 12 seconds
 
     management.http {
 //      host = 127.0.0.1

--- a/exercise_016_add_cluster_client/src/main/resources/application.conf
+++ b/exercise_016_add_cluster_client/src/main/resources/application.conf
@@ -21,7 +21,7 @@ akka {
 
   cluster {
 
-    seed-node-timeout = 60 seconds
+    seed-node-timeout = 12 seconds
 
     management.http {
 //      host = 127.0.0.1

--- a/exercise_017_clustered_sudoku_solver_cluster_client_enabled/src/main/resources/application.conf
+++ b/exercise_017_clustered_sudoku_solver_cluster_client_enabled/src/main/resources/application.conf
@@ -23,7 +23,7 @@ akka {
 
   cluster {
 
-    seed-node-timeout = 60 seconds
+    seed-node-timeout = 12 seconds
 
     management.http {
 //      host = 127.0.0.1

--- a/exercise_018_es_vizceral/src/main/resources/application.conf
+++ b/exercise_018_es_vizceral/src/main/resources/application.conf
@@ -23,7 +23,7 @@ akka {
 
   cluster {
 
-    seed-node-timeout = 60 seconds
+    seed-node-timeout = 12 seconds
 
     management.http {
 //      host = 127.0.0.1

--- a/exercise_019_es_opentracing/src/main/resources/application.conf
+++ b/exercise_019_es_opentracing/src/main/resources/application.conf
@@ -23,7 +23,7 @@ akka {
 
   cluster {
 
-    seed-node-timeout = 60 seconds
+    seed-node-timeout = 12 seconds
 
     management.http {
 //      host = 127.0.0.1

--- a/exercise_020_es_classic_console/src/main/resources/application.conf
+++ b/exercise_020_es_classic_console/src/main/resources/application.conf
@@ -23,7 +23,7 @@ akka {
 
   cluster {
 
-    seed-node-timeout = 60 seconds
+    seed-node-timeout = 12 seconds
 
     management.http {
 //      host = 127.0.0.1


### PR DESCRIPTION
The previous setting (60 seconds) makes the initial cluster formation (self-join of first seed node) too long