### PR TITLE
Add missing config Akka Management HTTP to one exercise

### DIFF
--- a/exercise_051_cluster_singleton_akka_bootstrap_discovery_via_akka_dns/src/main/resources/application.conf
+++ b/exercise_051_cluster_singleton_akka_bootstrap_discovery_via_akka_dns/src/main/resources/application.conf
@@ -8,6 +8,16 @@ akka {
   // to see what settings exist, uncomment the following line
   //log-config-on-start = on
 
+  management.http {
+    // This will allow one to alter the state of a cluster using Akka HTTP Management
+    // Setting this option to false may create a security exposure in production
+    // environments
+    route-providers-read-only = false
+
+    //host = 127.0.0.1
+    port = 8558
+  }
+
   // We'll use Akka Cluster Bootstrap with Discovery via akka-dns
   discovery.method = akka-dns
 


### PR DESCRIPTION
Config was missing on Akka Cluster Bootstrap with Discovery via DNS