### PR TITLE
Fix patch to enable utilisation of commercial license

### DIFF
--- a/ecl-patch/0001-Enable-utilisation-of-commercial-licenses.patch
+++ b/ecl-patch/0001-Enable-utilisation-of-commercial-licenses.patch
@@ -1,12 +1,8 @@
-From 1b25d3c5da8658f07f7047395b0399001f19fdd7 Mon Sep 17 00:00:00 2001
+From f9c00cdce12f54d0092cfd648a8eb0867fe07510 Mon Sep 17 00:00:00 2001
 From: Eric Loots <eric.loots@gmail.com>
-Date: Tue, 4 Jun 2019 09:09:18 +0200
-Subject: [PATCH] Enable utilisation of commercial licenses
+Date: Thu, 13 Jun 2019 19:07:44 +0200
+Subject: [PATCH 1/1] Enable utilisation of commercial licenses
 
-- This are the changes required to enable the utilisation of
-  commercial licenses
-- Needed at present for Lightbend Telemetry & Akka Cluster
-  Split Brain Resolver exercises
 ---
  project/CommonSettings.scala | 50 ++++++++++++++++++------------------
  project/Dependencies.scala   |  8 +++---
@@ -15,7 +11,7 @@ Subject: [PATCH] Enable utilisation of commercial licenses
  4 files changed, 35 insertions(+), 35 deletions(-)
 
 diff --git a/project/CommonSettings.scala b/project/CommonSettings.scala
-index d8c3b17..232a1f2 100644
+index 18afa57..6be19dc 100644
 --- a/project/CommonSettings.scala
 +++ b/project/CommonSettings.scala
 @@ -18,8 +18,8 @@
@@ -29,7 +25,7 @@ index d8c3b17..232a1f2 100644
  import sbt.Keys._
  import sbt._
  import sbtassembly._
-@@ -42,9 +42,9 @@ object CommonSettings {
+@@ -47,9 +47,9 @@ object CommonSettings {
      fork in Test := false,
      test in assembly := {},
      libraryDependencies ++= Dependencies.dependencies,
@@ -42,7 +38,7 @@ index d8c3b17..232a1f2 100644
    ) ++
      AdditionalSettings.initialCmdsConsole ++
      AdditionalSettings.initialCmdsTestConsole ++
-@@ -52,26 +52,26 @@ object CommonSettings {
+@@ -57,27 +57,27 @@ object CommonSettings {
  
    lazy val configure: Project => Project = (proj: Project) => {
      proj
@@ -87,8 +83,9 @@ index d8c3b17..232a1f2 100644
 +          oldStrategy(x)
 +      }
 +    )
-   }
- }
+       .enablePlugins(DockerPlugin, JavaAppPackaging)
+       .settings(
+       mappings in Universal += file("librpi_ws281x.so") -> "lib/librpi_ws281x.so",
 diff --git a/project/Dependencies.scala b/project/Dependencies.scala
 index d9a1b83..bc539ff 100644
 --- a/project/Dependencies.scala
@@ -133,16 +130,18 @@ index b317883..13f5f40 100644
 +resolvers += Resolver.url("com-ivy", url("https://repo.lightbend.com/commercial-releases/"))(Resolver.ivyStylePatterns)
 \ No newline at end of file
 diff --git a/project/plugins.sbt b/project/plugins.sbt
-index 69158ac..6ee44b7 100644
+index aa80956..9161c4d 100644
 --- a/project/plugins.sbt
 +++ b/project/plugins.sbt
-@@ -1,5 +1,5 @@
+@@ -1,7 +1,7 @@
  addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
  
  // Cinnamon
 -//addSbtPlugin("com.lightbend.cinnamon" % "sbt-cinnamon" % "2.10.12")
 +addSbtPlugin("com.lightbend.cinnamon" % "sbt-cinnamon" % "2.10.12")
  // Cinnamon
+ 
+ // SBT Native Packager
 -- 
 2.21.0
 


### PR DESCRIPTION
The patch to enable using commercial license stuff was not mergeable anymore as quite a number of PR's were merged since the patch was created. This may happen again in the future...
The approach using a patch is still the easiest I think...