### PR TITLE
Showing cluster state convergence

### DIFF
--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -11,7 +11,10 @@ cluster-status-indicator {
 
   cluster-leader-indicator-color = cyan
   cluster-heartbeat-indicator-color = whiteLow
+  cluster-heartbeat-indicator-convergence-color = green
+  cluster-heartbeat-indicator-no-convergence-color = red
   cluster-heartbeat-indicator-interval = 1000 millis
+  cluster-heartbeat-indicator-convergence-interval = 150 millis
   cluster-weakly-up-indicator-interval = 130 millis
 
   cluster-node-colors {

--- a/exercise_002_cluster_base/README.md
+++ b/exercise_002_cluster_base/README.md
@@ -38,3 +38,5 @@ In this exercise, we will explore the formation of an Akka Cluster with up-to
                 It blinks in red when the membership state of the cluster has not yet converged
                 It flashes 3 times in green when the membership state just converged
                 It blinks in white when the cluster is operating normally
+
+Note that in this exercise, the cluster gossip interval (and other parameters related to it) are slowed down on purpose in order to be able to get more time to see what is happening - normally, things move along faster. This is configured in `src/main/application.conf`.

--- a/exercise_002_cluster_base/README.md
+++ b/exercise_002_cluster_base/README.md
@@ -35,3 +35,6 @@ In this exercise, we will explore the formation of an Akka Cluster with up-to
 - LED number 7: Not used in this exercise
 - LED number 8: Cluster liveliness indicator: when it blinks, we know
                 that the cluster node software is actually running
+                It blinks in red when the membership state of the cluster has not yet converged
+                It flashes 3 times in green when the membership state just converged
+                It blinks in white when the cluster is operating normally

--- a/exercise_002_cluster_base/src/main/resources/application.conf
+++ b/exercise_002_cluster_base/src/main/resources/application.conf
@@ -36,6 +36,13 @@ akka {
                   "akka://pi-"${cluster-node-configuration.cluster-id}"-system@"${cluster-node-configuration.seed-node-2}":2550",
                   "akka://pi-"${cluster-node-configuration.cluster-id}"-system@"${cluster-node-configuration.seed-node-3}":2550",
                   "akka://pi-"${cluster-node-configuration.cluster-id}"-system@"${cluster-node-configuration.seed-node-4}":2550"]
+
+    gossip-interval = 2s
+    gossip-time-to-live = 4s
+    leader-actions-interval = 2s
+    unreachable-nodes-reaper-interval = 2s
+    publish-stats-interval = 500ms
+
   }
 
   remote {

--- a/exercise_002_cluster_base/src/main/resources/application.conf
+++ b/exercise_002_cluster_base/src/main/resources/application.conf
@@ -37,6 +37,8 @@ akka {
                   "akka://pi-"${cluster-node-configuration.cluster-id}"-system@"${cluster-node-configuration.seed-node-3}":2550",
                   "akka://pi-"${cluster-node-configuration.cluster-id}"-system@"${cluster-node-configuration.seed-node-4}":2550"]
 
+    # The intervals below are slowed down on purpose in order to show what is happening inside of Akka Cluster
+    # Usually you do not need to change those values and should only do so if you understand what they mean
     gossip-interval = 2s
     gossip-time-to-live = 4s
     leader-actions-interval = 2s

--- a/exercise_002_cluster_base/src/main/scala/akka/cluster/pi/ClusterStatusTrackerMain.scala
+++ b/exercise_002_cluster_base/src/main/scala/akka/cluster/pi/ClusterStatusTrackerMain.scala
@@ -18,12 +18,13 @@
   * limitations under the License.
   */
 
-package org.neopixel
+package akka.cluster.pi
 
+import org.neopixel._
+import _root_.neopixel.{rpi_ws281xConstants => wsC}
 import akka.actor.ActorSystem
 import akka.management.scaladsl.AkkaManagement
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
-import neopixel.{rpi_ws281xConstants => wsC}
 
 object ClusterStatusTrackerMain {
   def main(args: Array[String]): Unit = {

--- a/exercise_002_cluster_base/src/main/scala/akka/cluster/pi/ConfigSettingsExtension.scala
+++ b/exercise_002_cluster_base/src/main/scala/akka/cluster/pi/ConfigSettingsExtension.scala
@@ -1,24 +1,26 @@
 /**
-  * Copyright © 2016-2019 Lightbend, Inc.
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  * http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  *
-  * NO COMMERCIAL SUPPORT OR ANY OTHER FORM OF SUPPORT IS OFFERED ON
-  * THIS SOFTWARE BY LIGHTBEND, Inc.
-  *
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  */
+ * Copyright © 2016-2019 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * NO COMMERCIAL SUPPORT OR ANY OTHER FORM OF SUPPORT IS OFFERED ON
+ * THIS SOFTWARE BY LIGHTBEND, Inc.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-package org.neopixel
+package akka.cluster.pi
+
+import org.neopixel._
 
 import akka.actor.{Actor, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider}
 import com.typesafe.config.Config
@@ -82,8 +84,17 @@ class ConfigSettingsImpl(system: ExtendedActorSystem) extends Extension {
   val heartbeartIndicatorColor: Long =
     validateColor("cluster-status-indicator.cluster-heartbeat-indicator-color")
 
+  val heartbeartIndicatorConvergenceColor: Long =
+    validateColor("cluster-status-indicator.cluster-heartbeat-indicator-convergence-color")
+
+  val heartbeartIndicatorNoConvergenceColor: Long =
+    validateColor("cluster-status-indicator.cluster-heartbeat-indicator-no-convergence-color")
+
   val heartbeatIndicatorInterval: FiniteDuration =
     Duration(system.settings.config.getDuration("cluster-status-indicator.cluster-heartbeat-indicator-interval", Millis), Millis)
+
+  val clusterStateConvergenceInterval: FiniteDuration =
+    Duration(system.settings.config.getDuration("cluster-status-indicator.cluster-heartbeat-indicator-convergence-interval", Millis), Millis)
 
   object LedStripConfig {
 


### PR DESCRIPTION
This allows to show convergence:

- when no convergence is reached yet, the heartbeat blinks in red
- when a gossip was received in which all members have seen the latest state, the heartbeat blinks 3 times in green
- it then reverts to blinking in white

Some notes:

- classes moved to package `akka.cluster.pi` or else we can't follow the (internal) event
- gossip is slowed down so that it is possible to see things happen
- this is only applied to exercise 2 so far, since it might be distracting if it is shown all the time (and because I didn't want to introduce a PR with changes to package structure in all exercises)

I'll post a video about how this looks like online shortly.