### PR TITLE
Adjust led-count for new LED strips

### DIFF
--- a/common/src/main/resources/reference.conf
+++ b/common/src/main/resources/reference.conf
@@ -2,7 +2,7 @@
 cluster-status-indicator {
 
   led-brightness = 10
-  led-count      = 8       // Number of LED pixels on LED strip
+  led-count      = 10      // Number of LED pixels on LED strip
   led-pin        = 18      // GPIO pin connected to the pixels (must support PWM!)
   led-freq-hz    = 800000  // LED signal frequency in hertz (usually 800khz)
   led-dma        = 5       // DMA channel to use for generating signal (try 5)


### PR DESCRIPTION
- The new LED-strips have 10 LEDs while the `led-count` setting
  was still set to 8. This caused the ClusterStatusTracker to
  fail when LEDs 9 or 10 were used.
  This doesn't impact users working with the 'older' 8-LED type
  LED strips.