### PR TITLE
Rename package in tests

### DIFF
--- a/exercise_012_clustered_sudoku_solver/src/test/scala/akkapi/cluster/BaseAkkaSpec.scala
+++ b/exercise_012_clustered_sudoku_solver/src/test/scala/akkapi/cluster/BaseAkkaSpec.scala
@@ -1,4 +1,4 @@
-package akka.cluster.pi
+package akkapi.cluster
 
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import org.scalatest.BeforeAndAfterAll

--- a/exercise_012_clustered_sudoku_solver/src/test/scala/akkapi/cluster/BaseSpec.scala
+++ b/exercise_012_clustered_sudoku_solver/src/test/scala/akkapi/cluster/BaseSpec.scala
@@ -1,4 +1,4 @@
-package akka.cluster.pi
+package akkapi.cluster
 
 import org.scalatest.{Matchers, WordSpec}
 

--- a/exercise_012_clustered_sudoku_solver/src/test/scala/akkapi/cluster/CellMappingSpec.scala
+++ b/exercise_012_clustered_sudoku_solver/src/test/scala/akkapi/cluster/CellMappingSpec.scala
@@ -1,4 +1,4 @@
-package akka.cluster.pi
+package akkapi.cluster
 
 import org.scalatest.{Matchers, WordSpec}
 

--- a/exercise_012_clustered_sudoku_solver/src/test/scala/akkapi/cluster/ReductionRuleSpec.scala
+++ b/exercise_012_clustered_sudoku_solver/src/test/scala/akkapi/cluster/ReductionRuleSpec.scala
@@ -1,4 +1,4 @@
-package akka.cluster.pi
+package akkapi.cluster
 
 import org.scalatest.{Matchers, WordSpec}
 

--- a/exercise_012_clustered_sudoku_solver/src/test/scala/akkapi/cluster/SudokuDetailProcessorSpec.scala
+++ b/exercise_012_clustered_sudoku_solver/src/test/scala/akkapi/cluster/SudokuDetailProcessorSpec.scala
@@ -1,6 +1,6 @@
-package akka.cluster.pi
+package akkapi.cluster
 
-import akkapi.cluster.{Block, Row}
+import SudokuDetailProcessor.{BlockUpdate, SudokuDetailUnchanged, Update}
 
 class SudokuDetailProcessorSpec extends BaseAkkaSpec with SudokuTestHelpers {
 

--- a/exercise_012_clustered_sudoku_solver/src/test/scala/akkapi/cluster/SudokuTestHelpers.scala
+++ b/exercise_012_clustered_sudoku_solver/src/test/scala/akkapi/cluster/SudokuTestHelpers.scala
@@ -1,4 +1,4 @@
-package akka.cluster.pi
+package akkapi.cluster
 
 trait SudokuTestHelpers {
 


### PR DESCRIPTION
- The change in package name from `akka.cluster.pi` to `akkapi.cluster`
  in a previous PR was not applied for the test correct. This PR corrects
  that